### PR TITLE
fix/test/docs: 이미지 업로드 에러 UX 개선 + 기획 AI 실패 복구 E2E 테스트 + 상태 전이 다이어그램

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,163 @@ npm test
 
 ---
 
+## 🔍 System State Transition Diagram (QA Analysis)
+
+채팅 에이전트 시스템의 상태 전이를 LangGraph 소스코드 기반으로 분석한 다이어그램입니다.
+QA 관점에서 **정상 경로(Happy Path)** 와 **예외 경로(Error Path)** 를 함께 표현합니다.
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    [*] --> Lobby
+
+    %% ── 🏠 로비 ─────────────────────────────────────────────
+    state "🏠 로비 (Lobby)" as Lobby {
+        [*]         --> COORDINATOR
+        COORDINATOR --> DISCOVERY   : Discovery 의도 감지
+        DISCOVERY   --> Await_L     : await_input (트렌드/시즌 선택지)
+        COORDINATOR --> Await_L     : await_input (웰컴 메시지)
+        Await_L     --> [*]
+    }
+
+    Lobby --> InfoCollection : PROVIDE_INFO / CREATE 의도 감지
+    Lobby --> InfoCollection : Discovery 선택지 선택 완료
+
+    %% ── 📋 정보수집 ──────────────────────────────────────────
+    state "📋 정보수집 (Info Collection)" as InfoCollection {
+        [*]        --> INTAKE
+        INTAKE     --> CLARIFIER  : 모호한 답변 감지
+        CLARIFIER  --> INTAKE     : continue (명확화 완료)
+        CLARIFIER  --> Await_IC   : await_input (재질문)
+        INTAKE     --> SUGGESTER  : 필드 누락 (category / copyLength 등)
+        SUGGESTER  --> Await_IC   : await_input (순차 선택지 제시)
+        INTAKE     --> Await_IC   : await_input (추가 질문 중)
+        Await_IC   --> [*]
+
+        INTAKE     --> INTAKE_ERR  : ⚠ LLM API 호출 실패 (Gemini 오류)
+        INTAKE_ERR --> Await_IC    : 오류 메시지 반환 후 대기
+        CLARIFIER  --> CLARIFY_ERR : ⚠ LLM API 호출 실패
+        CLARIFY_ERR --> Await_IC   : 오류 메시지 반환 후 대기
+    }
+
+    InfoCollection --> Planning   : 필수 필드 완료 (productName · category · copyLength · imageModel)
+    InfoCollection --> UPLOAD_ERR : ⚠ /api/upload 실패 (R2 오류 / 네트워크)
+    UPLOAD_ERR     --> InfoCollection : toast 알림 후 재시도 가능
+
+    %% ── 🗂 기획 ──────────────────────────────────────────────
+    state "🗂 기획 (Planning)" as Planning {
+        [*]          --> PLANNER
+        PLANNER      --> PLAN_CONSULT : BEAUTY 카테고리 감지
+        PLANNER      --> Await_PL     : 플랜 제시 await_input
+        PLAN_CONSULT --> Await_PL     : 전문 플랜 제시 await_input
+        Await_PL     --> [*]
+
+        PLANNER      --> PLAN_ERR  : ⚠ LLM 플랜 생성 실패
+        PLAN_CONSULT --> PLAN_ERR  : ⚠ LLM 전문 플랜 생성 실패
+        PLAN_ERR     --> [*]
+    }
+
+    Planning   --> GenConfirm : generate 선택 (readyToGenerate=true)
+    Planning   --> Feedback   : modify 선택 (modifyRequest 설정)
+    Planning   --> Feedback   : ⚠ 기획 LLM 실패 → error 위임
+
+    %% ── ✅ 생성 확인 (이중 확인 구조) ───────────────────────
+    state "✅ 생성 확인 (Double-Check)" as GenConfirm {
+        [*]          --> DOUBLE_CHECK
+        DOUBLE_CHECK --> Await_GC : await_input (confirm / modify)
+        Await_GC     --> [*]
+    }
+
+    GenConfirm --> Generation : confirm 선택 (confirmedGenerate=true)
+    GenConfirm --> Feedback   : modify 재선택
+
+    %% ── ⚙️ 생성 ────────────────────────────────────────────
+    state "⚙️ 생성 (Generation)" as Generation {
+        [*]         --> DUP_CHECK
+        DUP_CHECK   --> SET_GEN    : 신규 요청
+        DUP_CHECK   --> EXIST_PROJ : ⚠ 중복 요청 감지 (status=GENERATING)
+        EXIST_PROJ  --> [*]
+
+        SET_GEN     --> FIELD_VALID
+        FIELD_VALID --> AI_GEN   : 필드 검증 통과
+        FIELD_VALID --> GEN_ERR  : ⚠ 필수 필드 누락 (getMissingFields)
+
+        AI_GEN      --> SAVE_DB   : AI 생성 성공 (generateDetailPage)
+        SAVE_DB     --> DEDUCT_CR : DB 저장 (DetailPageVersion · ProjectVersion)
+        DEDUCT_CR   --> COMPLETED : 크레딧 차감 (trialCredits--)
+        COMPLETED   --> [*]
+
+        AI_GEN    --> GEN_ERR : ⚠ AI API 타임아웃 / 실패
+        SAVE_DB   --> GEN_ERR : ⚠ DB 오류 (Prisma)
+        DEDUCT_CR --> GEN_ERR : ⚠ DB 오류 (크레딧 갱신 실패)
+        GEN_ERR   --> [*]
+    }
+
+    Generation --> Complete  : nextAction=complete (에디터 리다이렉트)
+    Generation --> Feedback  : nextAction=error (AI 생성 실패)
+    Complete   --> [*]
+
+    %% ── 🔄 피드백 ──────────────────────────────────────────
+    state "🔄 피드백 (Feedback)" as Feedback {
+        [*]        --> ANALYZE_FB
+        ANALYZE_FB --> Await_FB   : clarification (의도 불명확)
+        ANALYZE_FB --> FB_TO_PLAN : field_update / section_change
+        ANALYZE_FB --> FB_REGEN   : regenerate
+        Await_FB   --> [*]
+        FB_TO_PLAN --> [*]
+        FB_REGEN   --> [*]
+
+        ANALYZE_FB --> FB_ERR  : ⚠ LLM 피드백 분석 실패
+        FB_ERR     --> Await_FB : 오류 메시지 후 재입력 대기
+    }
+
+    Feedback --> Planning   : field_update / section_change
+    Feedback --> Generation : regenerate
+    Feedback --> End_Await  : await_input (clarification)
+    End_Await --> [*]
+
+    note right of Generation
+        ⚠ 전역 예외 — QA 체크포인트
+        ─────────────────────────────
+        세션 만료       → 401 → 로그인 리다이렉트
+        LLM Rate Limit  → Gemini 429 오류 (모든 LLM 호출 공통)
+        Graph 재귀 한도 → 50회 초과 시 강제 종료 (recursionLimit)
+        SSE 끊김        → 클라이언트 재연결 / 오류 표시 필요
+    end note
+```
+
+### 단계별 예외 (QA 체크포인트)
+
+| 단계 | 예외 | 코드 위치 | 실제 동작 |
+|------|------|-----------|-----------|
+| 정보수집 | LLM API 실패 (INTAKE/CLARIFIER) | `intake.ts` LLM 호출 블록 | 오류 메시지 → `await_input` |
+| 정보수집 | `/api/upload` 실패 | `chat-input.tsx` → `route.ts` | toast 알림 후 재시도 가능 |
+| 기획 | LLM 플랜 생성 실패 | `planner.ts` LLM 호출 블록 | `nextAction: error` → Feedback 위임 |
+| 생성 | 중복 요청 (`status=GENERATING`) | `generator.ts:18` | 기존 프로젝트 반환, 신규 생성 차단 |
+| 생성 | 필수 필드 누락 | `generator.ts:88` + `types.ts:484` | `GEN_ERR` → `nextAction: error` → Feedback |
+| 생성 | AI API 타임아웃/실패 | `generator.ts:243` | `GEN_ERR` → Feedback으로 라우팅 |
+| 생성 | DB 오류 | `generator.ts:129, 273, 334` | `GEN_ERR` → Feedback으로 라우팅 |
+| 피드백 | LLM 피드백 분석 실패 | `feedback.ts` LLM 호출 블록 | 오류 메시지 → `await_input` |
+
+### 전역 예외 (모든 단계 공통)
+
+| 예외 | 발생 위치 | 트리거 조건 |
+|------|-----------|-------------|
+| 세션 만료 | `messages/route.ts` 상단 auth 체크 | NextAuth 세션 없음 → 401 |
+| LLM Rate Limit | 모든 에이전트 LLM 호출 | Gemini 429 응답 |
+| Graph 재귀 초과 | `graph.ts:325` `recursionLimit: 50` | 에이전트 루프 50회 |
+| SSE 연결 끊김 | `route.ts` ReadableStream | 클라이언트 네트워크 단절 |
+
+### ⚠ 주의해야 할 QA 취약 구간
+
+1. **생성 확인 이중 구조** — `readyToGenerate=true` 후 COORDINATOR가 한 번 더 확인 메시지를 보내야 `confirmedGenerate=true`가 됨. 확인 없이 바로 생성 진입하는 경로 테스트 필요
+2. **이미지 스킵 키워드 의존** — `route.ts`에서 `'스킵/건너뛰/없어...'` 키워드 매칭으로 스킵 처리. 다른 표현 사용 시 `waitingForImageUpload` 상태에 갇힘
+3. **SUGGESTER 순차 루프** — 필드 완성 후 SUGGESTER가 다음 빈 필드로 계속 이동. 특정 필드 스킵 불가 시 무한 대기
+4. **Graph 재귀 50회 한도** — COORDINATOR ↔ 에이전트 루프 + Feedback ↔ 재생성 반복 시 도달 가능
+
+---
+
 ## 팀 구성
 
 | 이름 | 역할 | 담당 기능 |

--- a/src/app/(dashboard)/dashboard/chat/[conversationId]/_components/chat-input.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[conversationId]/_components/chat-input.tsx
@@ -9,6 +9,7 @@ import { useState, useRef, KeyboardEvent } from 'react';
 import { Send, Paperclip, X, Image as ImageIcon, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { useToast } from '@/hooks/use-toast';
 
 interface AttachmentItem {
   url: string;
@@ -27,6 +28,7 @@ export function ChatInput({
   disabled = false,
   placeholder = '메시지를 입력하세요...',
 }: ChatInputProps) {
+  const { toast } = useToast();
   const [message, setMessage] = useState('');
   const [attachments, setAttachments] = useState<AttachmentItem[]>([]);
   const [isUploading, setIsUploading] = useState(false);
@@ -75,7 +77,11 @@ export function ChatInput({
     const filesToUpload = Array.from(files).slice(0, remainingSlots);
 
     if (filesToUpload.length === 0) {
-      alert('이미지는 최대 5장까지 첨부할 수 있습니다.');
+      toast({
+        variant: 'destructive',
+        title: '첨부 제한 초과',
+        description: '이미지는 최대 5장까지 첨부할 수 있습니다.',
+      });
       return;
     }
 
@@ -125,7 +131,11 @@ export function ChatInput({
         console.error('이미지 업로드 실패:', error);
         // 실패한 항목 제거
         setAttachments((prev) => prev.filter((a) => a.url !== tempId));
-        alert('이미지 업로드에 실패했습니다.');
+        toast({
+          variant: 'destructive',
+          title: '업로드 실패',
+          description: '이미지 업로드에 실패했습니다. 다시 시도해 주세요.',
+        });
       }
     }
 

--- a/src/app/(dashboard)/dashboard/chat/[conversationId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/[conversationId]/page.tsx
@@ -186,7 +186,10 @@ export default function ChatPage() {
 
       {/* 에러 표시 */}
       {error && (
-        <div className="mx-4 mb-2 p-3 bg-red-50 border border-red-100 rounded-lg">
+        <div
+          data-testid="error-banner"
+          className="mx-4 mb-2 p-3 bg-red-50 border border-red-100 rounded-lg"
+        >
           <p className="text-sm text-red-600">{error}</p>
         </div>
       )}

--- a/tests/e2e/chat/chat.spec.ts
+++ b/tests/e2e/chat/chat.spec.ts
@@ -13,7 +13,7 @@
  * 사전 조건:
  *   - 개발 서버가 실행 중이거나 webServer 설정으로 자동 시작됨
  *   - TEST_USER_EMAIL / TEST_USER_PASSWORD 환경 변수 설정 (또는 기본값 사용)
- *   - auth.setup.ts 가 먼저 실행되어 .auth/user.json 에 세션이 저장됨
+ *   - auth.setup.ts 가 먼저 실행되어 .auth/user.json 에 세션이 저장됨.
  *
  * 모킹 전략:
  *   - AI 응답(LangGraph/Gemini): SSE 포맷으로 완전 모킹

--- a/tests/e2e/chat/planning-error-recovery.spec.ts
+++ b/tests/e2e/chat/planning-error-recovery.spec.ts
@@ -1,0 +1,414 @@
+/**
+ * 기획 단계 AI 실패 → UI 복구 검증
+ *
+ * 검증 대상: 시나리오 2 — PLANNER LLM 실패 시 UI가 안전하게 복구되는가
+ *
+ * ── 실제 코드 흐름 ────────────────────────────────────────────────────────
+ *
+ *  서버 (route.ts)
+ *    sendEvent('typing', { isTyping: true })   ← 라인 320
+ *    await graph.invoke(...)                   ← 라인 323 (여기서 LLM 실패)
+ *    catch → sendEvent('error', { message })   ← 라인 414
+ *    finally → controller.close()              ← 라인 418 (스트림 종료)
+ *
+ *  클라이언트 (use-sse-stream.ts → use-chat.ts)
+ *    typing 이벤트  → onTyping(true)
+ *      setIsTyping(true)                       ← use-chat.ts:119
+ *      messages에 임시 스트리밍 메시지 추가     ← use-chat.ts:125
+ *    error 이벤트  → onError(message)
+ *      setIsTyping(false)                      ← use-chat.ts:164  ★ typing-indicator 제거
+ *      setError(message)                       ← use-chat.ts:163  ★ 에러 배너 표시
+ *    스트림 종료 (finally)
+ *      setIsStreaming(false)                   ← use-sse-stream.ts:122 ★ textarea 활성화
+ *
+ *  렌더링 (page.tsx)
+ *    <TypingIndicator> 조건: isTyping && !messages.some(m => m.isStreaming)  ← 라인 179
+ *    <ChatInput disabled={isStreaming}>                                       ← 라인 197
+ *    {error && <div data-testid="error-banner">}                             ← 라인 188
+ *
+ * ── 에러 발생 시 임시 스트리밍 메시지 잔존 이슈 ─────────────────────────
+ *
+ *  onTyping(true) 에서 추가한 임시 메시지 { isStreaming: true, content: '' }는
+ *  onError에서 제거되지 않는다 (onDone에서만 정리됨 — use-chat.ts:144).
+ *  이 테스트는 해당 빈 메시지 버블이 UI에 표시되지 않음을 추가로 검증한다.
+ */
+
+import { test, expect } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
+import {
+  mockCreateConversation,
+  buildSSEErrorResponse,
+  buildSSEWithDoneData,
+  MOCK_CONVERSATION_ID,
+  MOCK_WELCOME_MESSAGE,
+} from '../helpers/chat-mocks';
+
+// ─── 픽스처 ────────────────────────────────────────────────────────────────
+
+/** imageModel 선택지를 제시한 직후 상태 (기획 직전) */
+const MESSAGES_BEFORE_PLANNING = [
+  MOCK_WELCOME_MESSAGE,
+  {
+    id: 'user-msg-1',
+    role: 'user',
+    content: '에어팟 프로 케이스 상세페이지 만들어줘',
+    agentType: null,
+    metadata: {},
+    attachments: [],
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
+  },
+  {
+    id: 'suggester-imagemodel',
+    role: 'assistant',
+    content:
+      '이미지 생성 모델을 선택해 주세요.\n\n• FLUX Pro: 고품질\n• FLUX Schnell: 빠른 생성',
+    agentType: 'SUGGESTER',
+    metadata: {
+      uiType: 'options',
+      options: [
+        { id: 'imageModel_FLUX_PRO', label: 'FLUX Pro (고품질)' },
+        { id: 'imageModel_FLUX_SCHNELL', label: 'FLUX Schnell (빠른 생성)' },
+      ],
+    },
+    attachments: [],
+    createdAt: new Date(Date.now() - 5_000).toISOString(),
+  },
+];
+
+// ─── 공통 세팅 헬퍼 ────────────────────────────────────────────────────────
+
+async function setupPlanningErrorScenario(
+  page: Page,
+  postHandler: (route: Route, callCount: number) => Promise<void>
+): Promise<void> {
+  await page.goto('/dashboard/chat');
+  await page.waitForLoadState('networkidle');
+  await mockCreateConversation(page);
+
+  let callCount = 0;
+
+  await page.route(
+    `**/api/chat/${MOCK_CONVERSATION_ID}/messages`,
+    async (route: Route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ messages: MESSAGES_BEFORE_PLANNING }),
+        });
+        return;
+      }
+
+      if (route.request().method() === 'POST') {
+        callCount += 1;
+        await postHandler(route, callCount);
+        return;
+      }
+
+      await route.continue();
+    }
+  );
+
+  await page
+    .getByTestId('new-chat-button')
+    .or(page.getByRole('button', { name: '새 대화' }))
+    .or(page.getByRole('button', { name: '첫 대화 시작하기' }))
+    .first()
+    .click();
+
+  await page.waitForURL(`**/dashboard/chat/${MOCK_CONVERSATION_ID}`, {
+    timeout: 10_000,
+  });
+  await page.waitForSelector('[data-testid="chat-textarea"]', { timeout: 10_000 });
+}
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  Connection: 'keep-alive',
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 메인 테스트
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('기획 AI 실패 → UI 복구', () => {
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-01: typing-indicator 제거 확인
+  // ──────────────────────────────────────────────────────────────────────────
+  test('T-01: SSE error 수신 후 typing-indicator가 사라진다', async ({ page }) => {
+    /**
+     * 검증 근거:
+     *   use-chat.ts:164  onError → setIsTyping(false)
+     *   page.tsx:179     isTyping && !isStreamingMsg → <TypingIndicator>
+     *
+     * isTyping=false 이므로 조건식이 false → TypingIndicator가 DOM에서 제거되어야 한다.
+     *
+     * 주의: route.fulfill()은 응답 전체를 한 번에 전송하므로
+     *   typing(true) → error 이벤트가 연속으로 처리된다.
+     *   React 18 배칭으로 인해 isTyping=true 상태가 렌더링되지 않을 수 있으므로
+     *   "표시됐다가 사라짐" 대신 "최종적으로 사라짐"을 단언한다.
+     */
+    await setupPlanningErrorScenario(page, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: SSE_HEADERS,
+        body: buildSSEErrorResponse('AI 플랜 생성에 실패했습니다. 다시 시도해 주세요.'),
+      });
+    });
+
+    // 메시지 전송 → PLANNER LLM 실패 유발
+    await page.fill('[data-testid="chat-textarea"]', 'FLUX Pro로 기획 시작해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // [단언] error 배너가 나타난 이후를 기점으로 typing-indicator 상태를 확인
+    // error-banner 가시성을 먼저 기다린 뒤 체크해야 경쟁 조건을 피할 수 있다
+    await expect(page.locator('[data-testid="error-banner"]')).toBeVisible({ timeout: 10_000 });
+
+    // typing-indicator는 이미 숨겨져 있어야 한다
+    await expect(page.locator('[data-testid="typing-indicator"]')).toBeHidden();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-02: textarea 재활성화 확인
+  // ──────────────────────────────────────────────────────────────────────────
+  test('T-02: SSE error 수신 후 textarea가 다시 활성화된다', async ({ page }) => {
+    /**
+     * 검증 근거:
+     *   use-sse-stream.ts:122  finally → setIsStreaming(false)
+     *   page.tsx:197           <ChatInput disabled={isStreaming}>
+     *   chat-input.tsx         <textarea disabled={disabled}>
+     *
+     * isStreaming=false가 된 순간 disabled 속성이 제거되어야 한다.
+     *
+     * 타이밍 참고:
+     *   error 이벤트 처리 → setIsTyping(false), setError(msg)  (isStreaming=true 유지)
+     *   스트림 종료 (finally) → setIsStreaming(false)           (textarea 활성화)
+     *   두 단계가 분리되어 있으므로 toBeEnabled에 충분한 timeout을 준다.
+     */
+    await setupPlanningErrorScenario(page, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: SSE_HEADERS,
+        body: buildSSEErrorResponse('AI 플랜 생성에 실패했습니다. 다시 시도해 주세요.'),
+      });
+    });
+
+    const textarea = page.locator('[data-testid="chat-textarea"]');
+
+    // 전송 전: textarea는 활성화 상태여야 한다
+    await expect(textarea).toBeEnabled();
+
+    await page.fill('[data-testid="chat-textarea"]', 'FLUX Pro로 기획 시작해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // 전송 직후: isStreaming=true → textarea는 비활성화된다
+    // (스트리밍 응답이 완료되기 전까지 disabled)
+    // → 이 상태는 짧으므로 단언하지 않고 복구 상태만 검증한다
+
+    // [단언 1] error-banner 등장 대기 (error 이벤트 처리 완료 기점)
+    await expect(page.locator('[data-testid="error-banner"]')).toBeVisible({ timeout: 10_000 });
+
+    // [단언 2] 스트림 종료 후 textarea는 반드시 활성화되어야 한다
+    //          isStreaming=false (finally 블록) 이 반영될 때까지 대기
+    await expect(textarea).toBeEnabled({ timeout: 5_000 });
+
+    // [단언 3] 실제로 텍스트를 입력할 수 있어야 한다 (포커스 가능 상태 확인)
+    await textarea.fill('다시 시도해볼게요');
+    await expect(textarea).toHaveValue('다시 시도해볼게요');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-03: 에러 배너 내용 확인
+  // ──────────────────────────────────────────────────────────────────────────
+  test('T-03: 서버가 보낸 에러 메시지가 에러 배너에 그대로 표시된다', async ({ page }) => {
+    /**
+     * 검증 근거:
+     *   use-chat.ts:163    onError → setError(errorMessage)
+     *   page.tsx:188-193   {error && <div data-testid="error-banner"><p>{error}</p>}
+     *
+     * 서버가 SSE error 이벤트에 담아 보낸 message 값이
+     * 그대로 error-banner 안에 렌더링되어야 한다.
+     */
+    const SERVER_ERROR_MESSAGE = 'Gemini API 호출 한도를 초과했습니다. 잠시 후 다시 시도해 주세요.';
+
+    await setupPlanningErrorScenario(page, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: SSE_HEADERS,
+        body: buildSSEErrorResponse(SERVER_ERROR_MESSAGE),
+      });
+    });
+
+    await page.fill('[data-testid="chat-textarea"]', '기획 시작해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // [단언] 에러 배너가 보이고 정확한 메시지를 포함한다
+    const errorBanner = page.locator('[data-testid="error-banner"]');
+    await expect(errorBanner).toBeVisible({ timeout: 10_000 });
+    await expect(errorBanner).toContainText(SERVER_ERROR_MESSAGE);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-04: 에러 후 재전송 가능 확인 (send-button 활성화)
+  // ──────────────────────────────────────────────────────────────────────────
+  test('T-04: 에러 복구 후 send-button이 활성화되고 재전송할 수 있다', async ({ page }) => {
+    /**
+     * 검증 근거:
+     *   chat-input.tsx  send-button disabled 조건:
+     *     disabled || isUploading || (!message.trim() && attachments.length === 0)
+     *
+     *   에러 후 disabled(=isStreaming)=false 이므로,
+     *   textarea에 텍스트가 있으면 send-button이 활성화된다.
+     */
+    await setupPlanningErrorScenario(page, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: SSE_HEADERS,
+        body: buildSSEErrorResponse('AI 플랜 생성에 실패했습니다.'),
+      });
+    });
+
+    // 1차 전송 → 실패 유발
+    await page.fill('[data-testid="chat-textarea"]', '기획 시작해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // error-banner 등장 대기
+    await expect(page.locator('[data-testid="error-banner"]')).toBeVisible({ timeout: 10_000 });
+
+    // [단언] 텍스트 입력 후 send-button 활성화
+    await page.fill('[data-testid="chat-textarea"]', '다시 기획해줘');
+    await expect(page.locator('[data-testid="send-button"]')).toBeEnabled({ timeout: 5_000 });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-05: 에러 후 실제 재전송 → 정상 응답 수신
+  // ──────────────────────────────────────────────────────────────────────────
+  test('T-05: 에러 복구 후 재전송 시 정상 기획안을 수신한다', async ({ page }) => {
+    /**
+     * 검증 근거:
+     *   1차 POST → SSE error → UI 복구
+     *   2차 POST → 정상 SSE → 기획안 메시지 렌더링
+     *
+     *   재전송 시 sendMessage 내부에서 setError(null)을 먼저 호출하므로
+     *   (use-chat.ts:252) error-banner도 사라져야 한다.
+     */
+    const RETRY_PLAN = '📋 기획안을 다시 작성했습니다. 섹션: HERO, FEATURES, FAQ';
+
+    await setupPlanningErrorScenario(page, async (route, callCount) => {
+      if (callCount === 1) {
+        // 1차: 실패
+        await route.fulfill({
+          status: 200,
+          headers: SSE_HEADERS,
+          body: buildSSEErrorResponse('AI 플랜 생성에 실패했습니다.'),
+        });
+      } else {
+        // 2차: 성공 (Feedback → Planning 복귀 시뮬레이션)
+        await route.fulfill({
+          status: 200,
+          headers: SSE_HEADERS,
+          body: buildSSEWithDoneData(RETRY_PLAN, {
+            status: 'await_input',
+            currentAgent: 'PLANNER',
+            collectedData: { plannedSections: ['HERO', 'FEATURES', 'FAQ'] },
+          }),
+        });
+      }
+    });
+
+    // 1차 전송 → 실패
+    await page.fill('[data-testid="chat-textarea"]', '기획 시작해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    await expect(page.locator('[data-testid="error-banner"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-testid="chat-textarea"]')).toBeEnabled({ timeout: 5_000 });
+
+    // 2차 전송 → 성공
+    await page.fill('[data-testid="chat-textarea"]', '다시 기획해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // [단언 1] 재전송 시 setError(null) 호출 → 에러 배너 사라짐
+    await expect(page.locator('[data-testid="error-banner"]')).toBeHidden({ timeout: 5_000 });
+
+    // [단언 2] 정상 기획안 메시지가 채팅에 나타남
+    await expect(
+      page.locator('[data-testid="message-item"]').filter({ hasText: '기획안을 다시 작성했습니다' }).first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // [단언 3] typing-indicator가 없음 (응답 완료 상태)
+    await expect(page.locator('[data-testid="typing-indicator"]')).toBeHidden();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-06: 에러 후 빈 ghost 메시지가 화면에 남지 않음
+  // ──────────────────────────────────────────────────────────────────────────
+  test('T-06: 에러 발생 시 빈 assistant 메시지 버블이 화면에 표시되지 않는다', async ({
+    page,
+  }) => {
+    /**
+     * 버그 방어 테스트:
+     *   onTyping(true) 에서 { id: tempId, content: '', isStreaming: true } 메시지를 추가.
+     *   onError에서는 이 메시지를 제거하지 않는다 (onDone에서만 정리).
+     *   → content가 빈 assistant 메시지가 DOM에 렌더링될 수 있음.
+     *
+     *   page.tsx:179의 TypingIndicator 조건:
+     *     isTyping && !messages.some(m => m.isStreaming)
+     *   온전한 상태라면 content='', isStreaming=true 메시지가 남아있어도
+     *   MessageItem 컴포넌트가 빈 content를 어떻게 처리하는지 확인한다.
+     */
+    await setupPlanningErrorScenario(page, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: SSE_HEADERS,
+        body: buildSSEErrorResponse('AI 플랜 생성에 실패했습니다.'),
+      });
+    });
+
+    const userMessageText = 'FLUX Pro로 기획 시작해줘';
+    await page.fill('[data-testid="chat-textarea"]', userMessageText);
+    await page.locator('[data-testid="send-button"]').click();
+
+    await expect(page.locator('[data-testid="error-banner"]')).toBeVisible({ timeout: 10_000 });
+
+    // [단언] message-item 중 텍스트가 없는(빈) assistant 버블이 없어야 한다
+    //        role=assistant이면서 보이는 텍스트가 없는 버블을 확인
+    const allMessageItems = page.locator('[data-testid="message-item"]');
+    const count = await allMessageItems.count();
+
+    for (let i = 0; i < count; i++) {
+      const item = allMessageItems.nth(i);
+      const text = await item.innerText();
+      // 완전히 빈 메시지 버블이면 안 됨 (공백만 있는 경우 포함)
+      expect(text.trim()).not.toBe('');
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-07: 에러 후 URL 이탈 없음 확인
+  // ──────────────────────────────────────────────────────────────────────────
+  test('T-07: 에러 발생 시 로비나 로그인 페이지로 이탈하지 않는다', async ({ page }) => {
+    await setupPlanningErrorScenario(page, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: SSE_HEADERS,
+        body: buildSSEErrorResponse('AI 플랜 생성에 실패했습니다.'),
+      });
+    });
+
+    await page.fill('[data-testid="chat-textarea"]', '기획 시작해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    await expect(page.locator('[data-testid="error-banner"]')).toBeVisible({ timeout: 10_000 });
+
+    // [단언 1] 채팅 페이지 URL 유지
+    await expect(page).toHaveURL(/\/dashboard\/chat\//);
+
+    // [단언 2] 로그인 페이지나 루트로 이탈하지 않음
+    await expect(page).not.toHaveURL(/\/login/);
+    await expect(page).not.toHaveURL(/^http:\/\/[^/]+\/$/);
+
+    // [단언 3] 에디터(projects)로도 이탈하지 않음
+    await expect(page).not.toHaveURL(/\/projects\//);
+  });
+});

--- a/tests/e2e/chat/state-transitions.spec.ts
+++ b/tests/e2e/chat/state-transitions.spec.ts
@@ -1,0 +1,539 @@
+/**
+ * 상태 전이 검증 E2E 테스트
+ *
+ * 상태 다이어그램 기반으로 핵심 상태 전이(Transition) 경로를 검증합니다.
+ *
+ * ┌─────────────────────────────────────────────────────────────────┐
+ * │  시나리오 1: 정보수집 → 기획 전환                              │
+ * │    SUGGESTER 순차 체크 완료 시 PLANNER가 정상 호출되는지 확인  │
+ * │                                                                 │
+ * │  시나리오 2: 기획 AI 실패 → 에러 복구 (핵심)                  │
+ * │    PLANNER LLM 오류 시 UI가 에러 메시지를 표시하고            │
+ * │    재입력 가능한 상태를 유지하는지 확인                        │
+ * │                                                                 │
+ * │  시나리오 3: 생성 이중 확인 → modify 선택 시 피드백 복귀      │
+ * │    readyToGenerate=true 후 COORDINATOR 확인 프롬프트가 뜨고,  │
+ * │    "수정" 선택 시 GENERATOR 호출 없이 피드백 상태로 복귀하는지 │
+ * └─────────────────────────────────────────────────────────────────┘
+ *
+ * SSE 이벤트 흐름 (정상):  typing(true) → chunk×N → message → typing(false) → done
+ * SSE 이벤트 흐름 (에러):  typing(true) → error
+ */
+
+import { test, expect } from '@playwright/test';
+import type { Route } from '@playwright/test';
+import {
+  mockCreateConversation,
+  buildSSEErrorResponse,
+  buildSSEWithDoneData,
+  MOCK_CONVERSATION_ID,
+  MOCK_WELCOME_MESSAGE,
+} from '../helpers/chat-mocks';
+
+// ─── 테스트용 메시지 픽스처 ────────────────────────────────────────────────
+
+/**
+ * 정보수집이 거의 완료된 상태.
+ * SUGGESTER가 마지막 항목인 imageModel 선택지를 제시한 직후를 재현합니다.
+ * (productName·category·copyLength 는 collectedData에 이미 저장된 상태)
+ */
+const MESSAGES_BEFORE_PLANNING = [
+  MOCK_WELCOME_MESSAGE,
+  {
+    id: 'user-msg-1',
+    role: 'user',
+    content: '에어팟 프로 케이스 상세페이지 만들어줘',
+    agentType: null,
+    metadata: {},
+    attachments: [],
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
+  },
+  {
+    id: 'suggester-imagemodel',
+    role: 'assistant',
+    content:
+      '이미지 생성 모델을 선택해 주세요.\n\n• FLUX Pro: 고품질, 사실적인 표현\n• FLUX Schnell: 빠른 생성, 스케치 느낌',
+    agentType: 'SUGGESTER',
+    metadata: {
+      uiType: 'options',
+      options: [
+        { id: 'imageModel_FLUX_PRO', label: 'FLUX Pro (고품질)' },
+        { id: 'imageModel_FLUX_SCHNELL', label: 'FLUX Schnell (빠른 생성)' },
+      ],
+    },
+    attachments: [],
+    createdAt: new Date(Date.now() - 5_000).toISOString(),
+  },
+];
+
+/**
+ * 기획 완료 상태.
+ * PLANNER/PLANNING_CONSULTANT가 기획안을 제시하고
+ * generate / modify_sections / modify_style 옵션이 표시된 직후를 재현합니다.
+ */
+const MESSAGES_AFTER_PLANNING = [
+  MOCK_WELCOME_MESSAGE,
+  {
+    id: 'planner-plan-msg',
+    role: 'assistant',
+    content:
+      '📋 기획안을 작성했습니다.\n\n**섹션 구성:** HERO → FEATURES → HOW_TO_USE → FAQ\n**스타일:** 미니멀 모던\n**톤앤매너:** 세련되고 간결한',
+    agentType: 'PLANNER',
+    metadata: {
+      uiType: 'plan_preview',
+      options: [
+        { id: 'generate', label: '이대로 생성하기' },
+        { id: 'modify_sections', label: '섹션 수정하기' },
+        { id: 'modify_style', label: '스타일 수정하기' },
+      ],
+    },
+    attachments: [],
+    createdAt: new Date(Date.now() - 5_000).toISOString(),
+  },
+];
+
+// ─── 공통 헬퍼: 모킹된 채팅 페이지 세팅 ──────────────────────────────────
+
+/**
+ * 채팅 목록 → 새 대화 → 대화 페이지까지 이동하고,
+ * GET /messages 와 POST /messages 를 각각 다르게 모킹합니다.
+ *
+ * @param page          - Playwright Page
+ * @param initialMessages - GET /messages 에서 반환할 초기 메시지 목록
+ * @param postHandler   - POST /messages 요청을 처리할 함수 (callCount 추적용)
+ */
+async function setupChatWithCustomMock(
+  page: Parameters<typeof mockCreateConversation>[0],
+  initialMessages: object[],
+  postHandler: (route: Route, callCount: number) => Promise<void>
+): Promise<void> {
+  await page.goto('/dashboard/chat');
+  await page.waitForLoadState('networkidle');
+  await mockCreateConversation(page);
+
+  let postCallCount = 0;
+
+  await page.route(
+    `**/api/chat/${MOCK_CONVERSATION_ID}/messages`,
+    async (route: Route) => {
+      const method = route.request().method();
+
+      if (method === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ messages: initialMessages }),
+        });
+        return;
+      }
+
+      if (method === 'POST') {
+        postCallCount += 1;
+        await postHandler(route, postCallCount);
+        return;
+      }
+
+      await route.continue();
+    }
+  );
+
+  // 새 대화 버튼 클릭 → 대화 페이지 이동
+  await page
+    .getByTestId('new-chat-button')
+    .or(page.getByRole('button', { name: '새 대화' }))
+    .or(page.getByRole('button', { name: '첫 대화 시작하기' }))
+    .first()
+    .click();
+
+  await page.waitForURL(`**/dashboard/chat/${MOCK_CONVERSATION_ID}`, {
+    timeout: 10_000,
+  });
+  await page.waitForSelector('[data-testid="chat-textarea"]', {
+    timeout: 10_000,
+  });
+}
+
+// ─── SSE 응답 헤더 상수 ────────────────────────────────────────────────────
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  Connection: 'keep-alive',
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 시나리오 1: 정보수집 → 기획 단계 전환
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('시나리오 1: 정보수집 → 기획 단계 전환', () => {
+  /**
+   * 검증 목표:
+   *   SUGGESTER가 imageModel 선택지를 제시한 상태에서 사용자가 선택하면
+   *   PLANNER 에이전트가 실행되어 기획안 메시지가 표시되어야 한다.
+   *
+   * 상태 전이:
+   *   InfoCollection (SUGGESTER:await_input)
+   *     → [imageModel 선택]
+   *     → Planning (PLANNER:await_input)
+   */
+  test('imageModel 선택 후 PLANNER의 기획안이 채팅에 표시된다', async ({ page }) => {
+    const PLAN_REPLY =
+      '📋 기획안을 작성했습니다.\n\n섹션: HERO, FEATURES, HOW_TO_USE\n스타일: 미니멀 모던';
+
+    await setupChatWithCustomMock(
+      page,
+      MESSAGES_BEFORE_PLANNING,
+      async (route) => {
+        // SUGGESTER → PLANNER 전환: PLANNER 응답을 시뮬레이션
+        await route.fulfill({
+          status: 200,
+          headers: SSE_HEADERS,
+          body: buildSSEWithDoneData(PLAN_REPLY, {
+            status: 'await_input',
+            currentAgent: 'PLANNER',
+            collectedData: {
+              productName: '에어팟 프로 케이스',
+              category: 'DIGITAL',
+              copyLength: 'MEDIUM',
+              imageModel: 'FLUX_PRO',
+              plannedSections: ['HERO', 'FEATURES', 'HOW_TO_USE'],
+            },
+          }),
+        });
+      }
+    );
+
+    // imageModel 선택 메시지 전송 (텍스트 입력으로 시뮬레이션)
+    await page.fill('[data-testid="chat-textarea"]', 'FLUX Pro로 선택할게요');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // [검증 1] 기획안 메시지가 채팅에 표시되어야 한다
+    await expect(
+      page.locator('[data-testid="message-item"]').filter({ hasText: '기획안을 작성했습니다' }).first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // [검증 2] 생성/수정 옵션 버튼이 표시되어야 한다 (기획 완료 상태의 트리거)
+    //          실제 UI 컴포넌트가 metadata.options 를 렌더링하면 버튼이 나타남
+    const generateBtn = page.getByRole('button', { name: /이대로 생성|섹션 수정|스타일 수정/i });
+    // 옵션 버튼이 있으면 검증, 없으면 메시지 존재로 대체 검증 (UI 구현에 따라 다름)
+    const hasPlanButtons = await generateBtn.first().isVisible({ timeout: 3_000 }).catch(() => false);
+    if (hasPlanButtons) {
+      await expect(generateBtn.first()).toBeVisible();
+    } else {
+      // 메시지에 섹션 키워드가 포함되어 있으면 기획 단계 도달로 간주
+      await expect(
+        page.locator('[data-testid="message-item"]').filter({ hasText: /HERO|FEATURES|섹션/i }).first()
+      ).toBeVisible({ timeout: 5_000 });
+    }
+
+    // [검증 3] URL이 채팅 페이지를 유지한다 (에디터로 이탈하면 안 됨)
+    await expect(page).toHaveURL(/\/dashboard\/chat\//);
+  });
+
+  test('기획 단계 도달 후 빈 입력으로는 전송할 수 없다 (await_input 상태 보장)', async ({
+    page,
+  }) => {
+    await setupChatWithCustomMock(
+      page,
+      MESSAGES_BEFORE_PLANNING,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          headers: SSE_HEADERS,
+          body: buildSSEWithDoneData('기획안 준비 완료!', {
+            status: 'await_input',
+            currentAgent: 'PLANNER',
+          }),
+        });
+      }
+    );
+
+    await page.fill('[data-testid="chat-textarea"]', 'FLUX Pro');
+    await page.keyboard.press('Enter');
+
+    // AI 응답 대기 후 textarea 비우기
+    await page.waitForSelector('[data-testid="message-item"]', { timeout: 10_000 });
+    await page.fill('[data-testid="chat-textarea"]', '');
+
+    // [검증] 텍스트가 없으면 전송 버튼이 비활성화 상태여야 한다
+    await expect(page.locator('[data-testid="send-button"]')).toBeDisabled();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 시나리오 2: 기획 단계 AI 실패 → 에러 복구 (핵심 시나리오)
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('시나리오 2: 기획 AI 실패 → 에러 복구', () => {
+  /**
+   * 검증 목표:
+   *   PLANNER LLM 호출(Gemini API)이 실패했을 때
+   *   - 서버가 SSE error 이벤트를 전송한다
+   *   - 클라이언트가 에러 메시지를 채팅에 표시한다
+   *   - 입력창(textarea)이 다시 활성화되어 재시도 가능한 상태가 된다
+   *   - 로비(/)나 에러 페이지로 이탈하지 않는다
+   *
+   * 상태 전이:
+   *   Planning (PLANNER)
+   *     → [Gemini API 타임아웃/실패]
+   *     → ⚠ SSE error 이벤트
+   *     → Feedback 대기 (재입력 가능 상태)
+   *
+   *   실제 서버 동작 (route.ts:411-416):
+   *     catch(error) { sendEvent('error', { message: error.message }); }
+   */
+  test('기획 AI 실패 시 에러 메시지가 표시되고 입력창이 활성화된다', async ({ page }) => {
+    const LLM_ERROR_MESSAGE = 'AI 플랜 생성에 실패했습니다. 다시 시도해 주세요.';
+
+    await setupChatWithCustomMock(
+      page,
+      MESSAGES_BEFORE_PLANNING,
+      async (route) => {
+        // PLANNER 노드에서 Gemini LLM 호출 실패 시뮬레이션
+        // 실제 route.ts catch 블록이 보내는 SSE와 동일한 형식:
+        //   event: typing / data: {"isTyping": true}
+        //   event: error  / data: {"message": "..."}
+        await route.fulfill({
+          status: 200,
+          headers: SSE_HEADERS,
+          body: buildSSEErrorResponse(LLM_ERROR_MESSAGE),
+        });
+      }
+    );
+
+    // 기획 진입 트리거: imageModel 선택 후 플랜 요청
+    await page.fill('[data-testid="chat-textarea"]', 'FLUX Pro 선택하고 기획 시작해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // ─── 검증 ─────────────────────────────────────────────────────────────
+
+    // [검증 1] 에러 메시지가 채팅창에 표시되어야 한다
+    //          빈 화면이나 무한 로딩 상태면 안 됨
+    await expect(
+      page
+        .locator('[data-testid="message-item"]')
+        .filter({ hasText: /실패|오류|에러|error/i })
+        .first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // [검증 2] typing-indicator(로딩 스피너)가 사라져야 한다
+    //          에러 후에도 "입력 중..." 상태가 유지되면 안 됨
+    await expect(page.locator('[data-testid="typing-indicator"]')).toBeHidden({
+      timeout: 5_000,
+    });
+
+    // [검증 3] textarea가 활성화 상태여야 한다 (재시도 가능)
+    const textarea = page.locator('[data-testid="chat-textarea"]');
+    await expect(textarea).toBeEnabled({ timeout: 5_000 });
+    await expect(textarea).toBeVisible();
+
+    // [검증 4] 텍스트 입력 후 전송 버튼이 활성화되어야 한다
+    await textarea.fill('다시 기획해줘');
+    await expect(page.locator('[data-testid="send-button"]')).toBeEnabled({ timeout: 3_000 });
+
+    // [검증 5] URL이 채팅 페이지를 유지한다 (로비 또는 /login 으로 이탈하면 안 됨)
+    await expect(page).toHaveURL(/\/dashboard\/chat\//);
+    await expect(page).not.toHaveURL(/\/login|^\//);
+  });
+
+  /**
+   * 검증 목표:
+   *   기획 AI 실패 후 사용자가 재시도 메시지를 보냈을 때
+   *   시스템이 다시 기획 단계를 수행하고 정상 응답을 반환해야 한다.
+   *
+   * 상태 전이:
+   *   ⚠ Planning 실패 → Feedback (재입력 대기)
+   *     → [사용자 재시도]
+   *     → Planning (PLANNER) → 정상 기획안 반환
+   */
+  test('기획 실패 후 재시도 메시지를 보내면 새 기획안이 표시된다', async ({ page }) => {
+    const LLM_ERROR_MESSAGE = 'AI 플랜 생성에 실패했습니다.';
+    const RETRY_PLAN_CONTENT = '다시 기획안을 작성했습니다! 섹션: HERO, FEATURES, FAQ';
+
+    // postCallCount 를 클로저로 추적
+    let postCallCount = 0;
+
+    await setupChatWithCustomMock(
+      page,
+      MESSAGES_BEFORE_PLANNING,
+      async (route, callCount) => {
+        postCallCount = callCount;
+
+        if (callCount === 1) {
+          // 첫 번째 요청: 기획 LLM 실패
+          await route.fulfill({
+            status: 200,
+            headers: SSE_HEADERS,
+            body: buildSSEErrorResponse(LLM_ERROR_MESSAGE),
+          });
+        } else {
+          // 두 번째 요청: 재시도 성공 (Feedback → Planning 복귀)
+          await route.fulfill({
+            status: 200,
+            headers: SSE_HEADERS,
+            body: buildSSEWithDoneData(RETRY_PLAN_CONTENT, {
+              status: 'await_input',
+              currentAgent: 'PLANNER',
+              collectedData: { plannedSections: ['HERO', 'FEATURES', 'FAQ'] },
+            }),
+          });
+        }
+      }
+    );
+
+    // 1차 전송 → 기획 실패
+    await page.fill('[data-testid="chat-textarea"]', '기획 시작해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // 에러 메시지 등장 대기
+    await expect(
+      page
+        .locator('[data-testid="message-item"]')
+        .filter({ hasText: /실패|오류/i })
+        .first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // 2차 전송 → 재시도
+    await page.fill('[data-testid="chat-textarea"]', '다시 기획해줘');
+    await page.locator('[data-testid="send-button"]').click();
+
+    // [검증 1] 재시도 성공 메시지가 표시되어야 한다
+    await expect(
+      page
+        .locator('[data-testid="message-item"]')
+        .filter({ hasText: '다시 기획안을 작성했습니다' })
+        .first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // [검증 2] 총 2번만 POST 호출됨 (GENERATOR가 호출되지 않았음)
+    expect(postCallCount).toBe(2);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 시나리오 3: 생성 이중 확인(GenConfirm) → modify 선택 시 피드백 복귀
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('시나리오 3: 생성 이중 확인 → modify 선택 시 피드백 복귀', () => {
+  /**
+   * 검증 목표:
+   *   기획 완료 후 "생성하기"를 선택하면 COORDINATOR가 이중 확인 프롬프트를 보내고,
+   *   사용자가 "수정"을 선택했을 때 GENERATOR가 호출되지 않고
+   *   피드백(Feedback) 상태로 안전하게 복귀해야 한다.
+   *
+   * 핵심 로직 (coordinator.ts:59-76):
+   *   if (readyToGenerate && !confirmedGenerate) → 이중 확인 메시지 + await_input
+   *   if (readyToGenerate && confirmedGenerate)  → GENERATOR 호출
+   *
+   * 상태 전이:
+   *   Planning (await_input)
+   *     → [generate 선택] → readyToGenerate=true
+   *     → GenConfirm (COORDINATOR:await_input) ← 이 테스트의 핵심 검증 지점
+   *     → [modify 선택]
+   *     → Feedback (FEEDBACK:await_input)      ← GENERATOR 미호출 확인
+   */
+  test('생성 확인 화면에서 modify 선택 시 GENERATOR 호출 없이 피드백 상태로 복귀한다', async ({
+    page,
+  }) => {
+    const CONFIRM_PROMPT =
+      '정말 생성하시겠어요? 지금 바로 생성하거나 섹션·스타일을 수정할 수 있습니다.';
+    const FEEDBACK_REPLY =
+      '어떤 부분을 수정하고 싶으신가요? 섹션 구성이나 스타일을 변경할 수 있습니다.';
+
+    let postCallCount = 0;
+
+    await setupChatWithCustomMock(
+      page,
+      MESSAGES_AFTER_PLANNING,
+      async (route, callCount) => {
+        postCallCount = callCount;
+        const body = await route.request().postDataJSON().catch(() => ({}));
+
+        if (callCount === 1) {
+          // "이대로 생성하기" 선택 → route.ts가 readyToGenerate=true 로 설정
+          // → COORDINATOR가 이중 확인 메시지 전송 (confirmedGenerate는 아직 false)
+          await route.fulfill({
+            status: 200,
+            headers: SSE_HEADERS,
+            body: buildSSEWithDoneData(CONFIRM_PROMPT, {
+              status: 'await_input',
+              currentAgent: 'COORDINATOR',
+              collectedData: {
+                readyToGenerate: true,
+                confirmedGenerate: false, // ← 이중 확인 대기 상태
+              },
+            }),
+          });
+        } else if (callCount === 2) {
+          // "수정" 선택 → modifyRequest 설정, confirmedGenerate는 여전히 false
+          // GENERATOR가 호출되면 안 됨
+          await route.fulfill({
+            status: 200,
+            headers: SSE_HEADERS,
+            body: buildSSEWithDoneData(FEEDBACK_REPLY, {
+              status: 'await_input',
+              currentAgent: 'FEEDBACK',
+              collectedData: {
+                readyToGenerate: false,
+                modifyRequest: 'sections',
+              },
+            }),
+          });
+        }
+      }
+    );
+
+    // ① "이대로 생성하기" 선택 — 버튼 또는 메시지로 시뮬레이션
+    const generateBtn = page.getByRole('button', { name: /이대로 생성|생성하기/i }).first();
+    const hasPlanBtn = await generateBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+
+    if (hasPlanBtn) {
+      await generateBtn.click();
+    } else {
+      await page.fill('[data-testid="chat-textarea"]', '이대로 생성해줘');
+      await page.locator('[data-testid="send-button"]').click();
+    }
+
+    // ② 이중 확인 메시지 대기
+    await expect(
+      page.locator('[data-testid="message-item"]').filter({ hasText: '정말 생성하시겠어요' }).first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // ③ "수정" 선택 — confirm 대신 modify 를 선택한다
+    const modifyBtn = page.getByRole('button', { name: /수정|취소|modify/i }).first();
+    const hasModifyBtn = await modifyBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+
+    if (hasModifyBtn) {
+      await modifyBtn.click();
+    } else {
+      await page.fill('[data-testid="chat-textarea"]', '아니요, 섹션 수정할게요');
+      await page.locator('[data-testid="send-button"]').click();
+    }
+
+    // ─── 검증 ─────────────────────────────────────────────────────────────
+
+    // [검증 1] 피드백 메시지가 표시되어야 한다
+    await expect(
+      page
+        .locator('[data-testid="message-item"]')
+        .filter({ hasText: '어떤 부분을 수정하고 싶으신가요' })
+        .first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // [검증 2] GENERATOR가 호출되지 않았음을 확인
+    //          POST 가 정확히 2번만 발생해야 한다 (generate 선택 + modify 선택)
+    //          3번째 호출이 발생했다면 GENERATOR 흐름으로 진입한 것
+    expect(postCallCount).toBe(2);
+
+    // [검증 3] "생성 중" 메시지나 프로그레스 UI가 없어야 한다
+    await expect(
+      page.locator('[data-testid="message-item"]').filter({ hasText: /생성 중|상세페이지 생성/i })
+    ).toHaveCount(0);
+
+    // [검증 4] URL이 채팅 페이지를 유지한다 (에디터로 이탈하면 안 됨)
+    await expect(page).toHaveURL(/\/dashboard\/chat\//);
+    await expect(page).not.toHaveURL(/\/projects\//);
+
+    // [검증 5] 입력창이 활성화 상태여야 한다 (피드백 입력 가능)
+    await expect(page.locator('[data-testid="chat-textarea"]')).toBeEnabled({ timeout: 5_000 });
+  });
+});

--- a/tests/e2e/helpers/chat-mocks.ts
+++ b/tests/e2e/helpers/chat-mocks.ts
@@ -255,6 +255,88 @@ export async function setupAndNavigateToChatPage(
   return MOCK_CONVERSATION_ID;
 }
 
+// ─── 추가 SSE 빌더 ─────────────────────────────────────────────────────────
+
+/**
+ * SSE 에러 이벤트를 생성합니다.
+ * route.ts catch 블록이 실제로 보내는 형식과 동일:
+ *   typing(true) → error
+ *
+ * @param errorMessage - 클라이언트에 전달할 오류 메시지
+ */
+export function buildSSEErrorResponse(errorMessage: string): string {
+  const makeEvent = (name: string, data: object) =>
+    `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+
+  return [
+    makeEvent('typing', { isTyping: true }),
+    makeEvent('error', { message: errorMessage }),
+  ].join('');
+}
+
+/**
+ * done 이벤트에 임의의 상태(collectedData, currentAgent 등)를 담은 SSE를 생성합니다.
+ * 특정 상태(기획 완료, 생성 확인 등)를 테스트에서 재현할 때 사용합니다.
+ *
+ * @param replyContent - 스트리밍할 AI 메시지 텍스트
+ * @param donePayload  - done 이벤트에 포함할 추가 데이터 (currentAgent, collectedData 등)
+ * @param messageId    - 메시지 ID (기본값: 자동 생성)
+ */
+export function buildSSEWithDoneData(
+  replyContent: string,
+  donePayload: {
+    status?: string;
+    currentAgent?: string;
+    collectedData?: Record<string, unknown>;
+    projectId?: string;
+  },
+  messageId = `ai-msg-${Date.now()}`
+): string {
+  const makeEvent = (name: string, data: object) =>
+    `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+
+  const events: string[] = [];
+
+  events.push(makeEvent('typing', { isTyping: true }));
+
+  const tokens = replyContent.match(/\S+|\s+/g) ?? [replyContent];
+  let accumulated = '';
+  tokens.forEach((token, i) => {
+    accumulated += token;
+    events.push(
+      makeEvent('chunk', {
+        messageId,
+        content: accumulated,
+        isComplete: i === tokens.length - 1,
+      })
+    );
+  });
+
+  events.push(
+    makeEvent('message', {
+      id: messageId,
+      role: 'assistant',
+      content: replyContent,
+      agentType: donePayload.currentAgent ?? 'COORDINATOR',
+      metadata: {},
+      createdAt: new Date().toISOString(),
+    })
+  );
+
+  events.push(makeEvent('typing', { isTyping: false }));
+
+  events.push(
+    makeEvent('done', {
+      status: donePayload.status ?? 'await_input',
+      currentAgent: donePayload.currentAgent ?? 'COORDINATOR',
+      collectedData: donePayload.collectedData ?? {},
+      ...(donePayload.projectId && { projectId: donePayload.projectId }),
+    })
+  );
+
+  return events.join('');
+}
+
 /** 테스트용 샘플 이미지 경로 (200×200 보라-인디고 그라디언트 PNG) */
 export const SAMPLE_IMAGE_PATH = path.join(
   __dirname,


### PR DESCRIPTION
## 배경 (Background)

채팅 서비스의 기획 단계에서 LangGraph PLANNER 노드가 Gemini LLM을 호출할 때
타임아웃·Rate Limit·API 오류 등이 발생하면 서버는 SSE `error` 이벤트를 전송합니다.
이때 클라이언트 UI가 안전하게 복구되는지(타이핑 인디케이터 제거, textarea 재활성화)
검증하는 테스트가 없었고, 이미지 업로드 실패 시 `alert()` 팝업으로 사용자 경험을
방해하는 문제도 함께 수정했습니다.
또한 소스코드 분석을 통해 도출한 상태 전이 다이어그램을 README에 추가하여
시스템 동작과 QA 취약 구간을 문서화했습니다.

---

## 변경 사항 (Changes)

### 1. `fix` — 이미지 업로드 에러 UX 개선

**파일:** `src/app/(dashboard)/dashboard/chat/[conversationId]/_components/chat-input.tsx`

브라우저 기본 `alert()`를 shadcn/ui `toast`로 교체했습니다.

| 상황 | Before | After |
|------|--------|-------|
| 이미지 5장 초과 첨부 시도 | `alert('이미지는 최대 5장...')` | `toast({ variant: 'destructive', title: '첨부 제한 초과' })` |
| `/api/upload` 업로드 실패 | `alert('이미지 업로드에 실패...')` | `toast({ variant: 'destructive', title: '업로드 실패' })` |

`alert()`는 브라우저 UI를 동기적으로 블로킹하고 앱 디자인 시스템과 일관성이 없는 UX 문제였습니다.

---

### 2. `test` — 기획 AI 실패 → UI 복구 E2E 테스트 (T-01 ~ T-07)

**파일:** `tests/e2e/chat/planning-error-recovery.spec.ts`

SSE `error` 이벤트 수신 시 클라이언트 상태 복구를 검증합니다.

#### 실제 코드 흐름 (테스트 설계 근거)

```
서버 route.ts
  sendEvent('typing', { isTyping: true })   ← 라인 320
  await graph.invoke(...)                   ← LLM 호출 실패 지점
  catch → sendEvent('error', { message })   ← 라인 414
  finally → controller.close()             ← 라인 418

클라이언트 use-sse-stream.ts → use-chat.ts
  typing 이벤트  → setIsTyping(true)           ← typing-indicator 표시
  error 이벤트   → setIsTyping(false)           ← typing-indicator 제거 ★
                   setError(message)            ← error-banner 표시 ★
  스트림 종료 (finally) → setIsStreaming(false) ← textarea 활성화 ★
```

> `isTyping`과 `isStreaming`은 **서로 다른 시점**에 해제됩니다.
> error 이벤트 처리 → `isTyping=false` (즉시) / 스트림 종료 → `isStreaming=false` (지연 가능).
> 각 단언에 error-banner 등장을 기준점으로 삼아 경쟁 조건을 피했습니다.

#### 테스트 목록

| ID | 검증 내용 | 발견 가능한 버그 |
|----|-----------|-----------------|
| T-01 | SSE error 후 `typing-indicator` 숨김 | 에러 후 로딩 표시 고착 |
| T-02 | `isStreaming=false`(finally) 후 `textarea` 활성화 | textarea 영구 비활성화 |
| T-03 | 서버 에러 메시지가 `error-banner`에 그대로 표시 | 에러 메시지 누락 |
| T-04 | 에러 복구 후 `send-button` 활성화 | 재전송 불가 상태 |
| T-05 | 재전송 → 정상 응답 수신 + `error-banner` 자동 제거 | error-banner 잔존 |
| T-06 | `onTyping(true)`로 추가된 빈 ghost 메시지 버블 미표시 | 빈 assistant 버블 잔존 |
| T-07 | 에러 발생 시 URL 이탈(로그인/에디터) 없음 | 에러 시 강제 리다이렉트 |

> **T-06 설계 의도:** `use-chat.ts:125`의 `onTyping(true)`가 추가한 임시 메시지
> `{ content: '', isStreaming: true }`는 `onError`에서 정리되지 않고 `onDone`에서만 정리됩니다.
> error 경로에서는 `onDone`이 호출되지 않으므로, 빈 버블이 UI에 남을 수 있는 잠재적 버그를 조기 감지합니다.

---

### 3. `docs` — README 상태 전이 다이어그램 추가

**파일:** `README.md`

LangGraph 소스코드 분석을 기반으로 도출한 시스템 상태 전이 다이어그램과
QA 관점 예외 경로 분석을 README에 추가했습니다.

- **Mermaid stateDiagram-v2**: 로비·정보수집·기획·생성확인·생성·피드백 5단계 전이 표현
- **단계별 예외 테이블**: LLM 실패, DB 오류, 중복 요청 등 8가지 예외와 코드 위치 명시
- **전역 예외 테이블**: 세션 만료, Rate Limit, Graph 재귀 초과, SSE 끊김
- **QA 취약 구간 4가지**: 이중 확인 구조, 스킵 키워드 의존, SUGGESTER 루프, 재귀 한도

---

### 4. 테스트 인프라 보강

**`tests/e2e/helpers/chat-mocks.ts`** — 헬퍼 2개 추가

| 함수 | 역할 |
|------|------|
| `buildSSEErrorResponse(msg)` | `typing(true) → error` 형식의 SSE 문자열 생성 (서버 catch 블록과 동일한 형식) |
| `buildSSEWithDoneData(content, payload)` | `done` 이벤트에 임의의 `currentAgent·collectedData`를 주입한 SSE 생성 |

**`src/app/(dashboard)/dashboard/chat/[conversationId]/page.tsx`**
- error 배너에 `data-testid="error-banner"` 추가 (테스트 셀렉터용)

---

## 테스트 실행 방법 (Test Plan)

```bash
# 전체 E2E 실행
npx playwright test

# 이번 PR 테스트만 실행
npx playwright test tests/e2e/chat/planning-error-recovery.spec.ts

# UI 모드로 디버깅
npx playwright test tests/e2e/chat/planning-error-recovery.spec.ts --ui
```

- [ ] T-01: SSE error 후 typing-indicator 숨김 확인
- [ ] T-02: textarea 재활성화 확인 (isStreaming=false 타이밍)
- [ ] T-03: 에러 배너 메시지 정확도 확인
- [ ] T-04: send-button 재활성화 확인
- [ ] T-05: 재전송 후 error-banner 자동 제거 확인
- [ ] T-06: 빈 ghost 메시지 버블 없음 확인
- [ ] T-07: URL 이탈 없음 확인
- [ ] 이미지 5장 초과 시 toast 표시 확인 (alert 팝업 없음)
- [ ] /api/upload 실패 시 toast 표시 확인
- [ ] README Mermaid 다이어그램 GitHub 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)